### PR TITLE
fix: exclude `constructor.prototype`

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,13 @@ function defaultsDeep(target, objects) {
 
   function copy(target, current) {
     lazy.forOwn(current, function (value, key) {
-      if (key === '__proto__') {
+      if (key === '__proto__' ||
+        (key === 'constructor' && value && value.prototype)) {
         return;
       }
 
       var val = target[key];
+
       // add the missing property, or allow a null property to be updated
       if (val == null) {
         target[key] = value;

--- a/index.js
+++ b/index.js
@@ -16,8 +16,7 @@ function defaultsDeep(target, objects) {
 
   function copy(target, current) {
     lazy.forOwn(current, function (value, key) {
-      if (key === '__proto__' ||
-        (key === 'constructor' && value && value.prototype)) {
+      if (key === '__proto__' || (key === 'constructor' && value && value.prototype)) {
         return;
       }
 

--- a/test.js
+++ b/test.js
@@ -41,6 +41,6 @@ describe('deep-defaults', function () {
   it('should not override Object prototype', function () {
     var payload = JSON.parse('{"constructor": {"prototype": {"isAdmin": true}}}');
     deepDefaults({}, payload);
-    ({}).isAdmin.should.eql(false)
+    (({}).isAdmin || false).should.eql(false)
   })
 });

--- a/test.js
+++ b/test.js
@@ -37,4 +37,10 @@ describe('deep-defaults', function () {
   it('should return an empty object when the first arg is null.', function () {
     deepDefaults(null).should.eql({});
   });
+
+  it('should not override Object prototype', function () {
+    var payload = JSON.parse('{"constructor": {"prototype": {"isAdmin": true}}}');
+    deepDefaults({}, payload);
+    ({}).isAdmin.should.eql(false)
+  })
 });


### PR DESCRIPTION
Fix prototype pollution:
- fix https://www.npmjs.com/advisories/778
- fix https://hackerone.com/reports/380878 (CVE-2018-16486)
- add a test to prevent regressions

Related commit: c873f341327ad885ff4d0f23b3d3bca31b0343e5 (exclude `__proto__`) in 2.4.0

Similar lodash fix: https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad