### PR TITLE
Address Prototype Pollution vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,19 @@ var lazy = require('lazy-cache')(require);
 lazy('is-extendable', 'isObject');
 lazy('for-own', 'forOwn');
 
+// Prevent prototype pollution (inject properties into language construct prototypes)
+var protectedAttributes = [
+  '__proto__',
+  'constructor',
+  'prototype'
+];
+
 function defaultsDeep(target, objects) {
   target = target || {};
 
   function copy(target, current) {
     lazy.forOwn(current, function (value, key) {
-      if (key === '__proto__') {
+      if (protectedAttributes.indexOf(key) !== -1) {
         return;
       }
 

--- a/test.js
+++ b/test.js
@@ -37,4 +37,21 @@ describe('deep-defaults', function () {
   it('should return an empty object when the first arg is null.', function () {
     deepDefaults(null).should.eql({});
   });
+
+  it('should prevent prototype pollution by disallowing construct properties access', function() {
+    var obj = { prototype: Object.prototype };
+
+    deepDefaults(obj, {
+      constructor: {
+        prototype: { isAdmin: true },
+        a: 'b'
+      },
+      __proto__: { a: 'b' },
+      prototype: { a: 'b' }
+    });
+    obj.constructor.should.not.have.property('a');
+    obj.__proto__.should.not.have.property('a');
+    obj.prototype.should.not.have.property('a');
+    ({}).should.not.have.property('isAdmin');
+  });
 });


### PR DESCRIPTION
### TL;DR
This vulnerability exposes language construct prototypes to unwanted modifications

```js
defaultsDeep(
  {},
  { constructor: { prototype: { isAdmin: true } } }
);

console.log({}.isAdmin); // true for all objects now
```

Further reading:
- [Prototype Pollution attack](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)

Open reports:
- [NPM advisory](https://www.npmjs.com/advisories/778)
- [Snyk CVE](https://app.snyk.io/vuln/SNYK-JS-DEFAULTSDEEP-173661)
- [Hackerone report](https://hackerone.com/reports/380878)
